### PR TITLE
Add egress rule back to main.tf

### DIFF
--- a/terraform/service/main.tf
+++ b/terraform/service/main.tf
@@ -15,6 +15,12 @@ resource "aws_security_group" "lambda_sg" {
     protocol    = "tcp"
     cidr_blocks = ["10.0.0.0/16"] // Allow HTTPS traffic within VPC
   }
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"] // Allow all outbound traffic
+  }
 }
 
 resource "aws_lambda_function" "lambda_function" {


### PR DESCRIPTION
# Overview
When deploying to sdp-prod, any outbound traffic times out. This is because there are no outbound rules within the Lambda's security group.

The egress rules were removed during linting and ran fine on sdp-dev. Terraform did not pick up the egress rules being removed, hence it working on sdp-dev and not sdp-prod.

This PR reimplements the egress rules to allow outbound traffic.

This does fail linting but is required to run on AWS.