### PR TITLE
KEH-674 + KEH-675 | Fix Terraform Linting Errors

### DIFF
--- a/.checkov.yml
+++ b/.checkov.yml
@@ -13,7 +13,4 @@ skip-check:
 
   # These ignores are TEMPORARY. They will be resolved in the future.
   - CKV_AWS_108
-  - CKV_TF_1
-  - CKV_TF_2
-  - CKV_AWS_115
   - CKV_AWS_272

--- a/.checkov.yml
+++ b/.checkov.yml
@@ -11,6 +11,9 @@ skip-check:
   - CKV_AWS_158
   - CKV_AWS_338
 
+  # Pin module sources to a commit hash (false positive)
+  - CKV_TF_1
+
   # These ignores are TEMPORARY. They will be resolved in the future.
   - CKV_AWS_108
   - CKV_AWS_272

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -85,7 +85,8 @@ jobs:
 
         # You can override MegaLinter flavor used to have faster performances
         # More info at https://megalinter.io/latest/flavors/
-        uses: oxsecurity/megalinter@v8
+        # The below commit hash is v8.8.0
+        uses: oxsecurity/megalinter@e08c2b05e3dbc40af4c23f41172ef1e068a7d651
 
         id: ml
 

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -85,7 +85,7 @@ jobs:
 
         # You can override MegaLinter flavor used to have faster performances
         # More info at https://megalinter.io/latest/flavors/
-        uses: oxsecurity/megalinter@1fc052d03c7a43c78fe0fee19c9d648b749e0c01
+        uses: oxsecurity/megalinter@v8
 
         id: ml
 

--- a/Makefile
+++ b/Makefile
@@ -53,4 +53,4 @@ megalint:  ## Run the mega-linter.
 	docker run --platform linux/amd64 --rm \
 		-v /var/run/docker.sock:/var/run/docker.sock:rw \
 		-v $(shell pwd):/tmp/lint:rw \
-		oxsecurity/megalinter:v7
+		oxsecurity/megalinter:v8

--- a/kics.config
+++ b/kics.config
@@ -10,3 +10,6 @@ exclude-queries:
 
   # Sensitive Port Exposed to Private Network (This is fine due to VPC)
   - 92fe237e-074c-4262-81a4-2077acb928c1
+
+  # Megalinter Action pinning to @v8 instead of a commit hash
+  - 555ab8f9-2001-455e-a077-f2d0f41e2fb9

--- a/kics.config
+++ b/kics.config
@@ -10,6 +10,3 @@ exclude-queries:
 
   # Sensitive Port Exposed to Private Network (This is fine due to VPC)
   - 92fe237e-074c-4262-81a4-2077acb928c1
-
-  # Megalinter Action pinning to @v8 instead of a commit hash
-  - 555ab8f9-2001-455e-a077-f2d0f41e2fb9

--- a/terraform/service/eventbridge.tf
+++ b/terraform/service/eventbridge.tf
@@ -1,5 +1,6 @@
 module "eventbridge" {
   source = "terraform-aws-modules/eventbridge/aws"
+  version = "4.1.0"
 
   role_name = "${var.lambda_name}-eventbridge-role"
 

--- a/terraform/service/eventbridge.tf
+++ b/terraform/service/eventbridge.tf
@@ -1,6 +1,9 @@
 module "eventbridge" {
-  source = "terraform-aws-modules/eventbridge/aws"
-  version = "4.1.0"
+  # source  = "terraform-aws-modules/eventbridge/aws"
+  # version = "4.1.0"
+
+  # Pin to a git commit instead. This is the same as the above.
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-eventbridge.git?ref=3e8657cd925d5b4a21301a09b67d8081f24bcfc3"
 
   role_name = "${var.lambda_name}-eventbridge-role"
 

--- a/terraform/service/eventbridge.tf
+++ b/terraform/service/eventbridge.tf
@@ -1,9 +1,6 @@
 module "eventbridge" {
-  # source  = "terraform-aws-modules/eventbridge/aws"
-  # version = "4.1.0"
-
-  # Pin to a git commit instead. This is the same as the above.
-  source = "git::https://github.com/terraform-aws-modules/terraform-aws-eventbridge.git?ref=3e8657cd925d5b4a21301a09b67d8081f24bcfc3"
+  source  = "terraform-aws-modules/eventbridge/aws"
+  version = "4.1.0"
 
   role_name = "${var.lambda_name}-eventbridge-role"
 

--- a/terraform/service/main.tf
+++ b/terraform/service/main.tf
@@ -43,6 +43,8 @@ resource "aws_lambda_function" "lambda_function" {
 
   memory_size = var.lambda_memory
 
+  reserved_concurrent_executions = 100
+
   role = aws_iam_role.lambda_function_role.arn
 
   environment {


### PR DESCRIPTION
# What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## What

In this PR, I will remove the follow linting errors from being excluded and address them properly:

- CKV_AWS_115: Add a concurrent execution limit.
- CKV_AWS_TF1/2: Pin remote Terraform modules to a particular GitHub commit. This is more secure than using an AWS TF Registry release.

### Testing

Have any new tests been added as part of this issue? If not, try to explain why test coverage is not needed here.

- [ ] Yes
- [x] No
Please write a brief description of why test coverage is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Documentation

Has any new documentation been written as part of this issue? We should try to keep documentation up to date
as new code is added, rather than leaving it for the future.

- [ ] Yes
- [x] No
Please write a brief description of why documentation is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Related issues

KEH-674 + KEH-675 (Jira)

### How to review

Linting should pass if this PR is successful.
