### PR TITLE
docs: add comment to justify linting ignore

### DIFF
--- a/.checkov.yml
+++ b/.checkov.yml
@@ -14,5 +14,7 @@ skip-check:
   # Pin module sources to a commit hash (false positive)
   - CKV_TF_1
 
-  # These ignores are TEMPORARY. They will be resolved in the future.
+  # Ignore adding code-signing to Lambda.
+  # It is not needed here since our Lambda functions use container
+  # images over uploading .zip files for layers.
   - CKV_AWS_272


### PR DESCRIPTION
## Overview

Add justification for ignoring `CKV_AWS_272`.

Since we use container images for our Lambdas, code signing is not needed.
